### PR TITLE
Run `.toLowerCase()` when checking file types

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -630,7 +630,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 		}
 
-		const fileType = readMagicBytes( buffer ) || extension;
+		const fileType = readMagicBytes( buffer ).toLowerCase() || extension.toLowerCase();
 		switch ( fileType ) {
 
 			case 'b3dm': {


### PR DESCRIPTION
Run `.toLowerCase()` on file types to account for Google's Photorealistic 3D tiles returning as 'glTF'.